### PR TITLE
Remove a workaround comment exists in goci-interfaces/goci-curation/pom.xml file since the workaround has been adopted.

### DIFF
--- a/goci-interfaces/goci-curation/pom.xml
+++ b/goci-interfaces/goci-curation/pom.xml
@@ -63,7 +63,7 @@
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
 
-        <!--&lt;!&ndash; workaround for https://github.com/spring-projects/spring-boot/issues/2124 &ndash;&gt;-->
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>


### PR DESCRIPTION
I think the workaround for https://github.com/spring-projects/spring-boot/issues/2124 has been adopted in goci project, since this bug has been fixed in spring-boot-starter-actuator:1.4.2 according to https://github.com/spring-projects/spring-boot/issues/2142#issuecomment-259115996

Thus, this workaround comment could be removed.

The comment:
https://github.com/EBISPOT/goci/blob/af9d82a2690cdf721f2be7d35a93b8a3f993bd58/goci-interfaces/goci-curation/pom.xml#L66